### PR TITLE
add: visualize grid, source, receivers, and ray paths

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,3 +5,4 @@ version = "0.1.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"

--- a/src/Visualization.jl
+++ b/src/Visualization.jl
@@ -1,0 +1,47 @@
+module Visualization
+
+using Plots
+
+using ..Grids
+
+export plot_grid_rays
+
+"""
+    plot_grid_rays(grid, src, recs; heatmap_col=:tab20)
+
+Visualize the grid, sources, receivers, and ray paths.
+
+For debugging purposes.
+"""
+function plot_grid_rays(grid::Grid{I,T}, src::Point{T}, recs::Array{Point{T},1}; heatmap_col=:tab20) where {I, T}
+    # Plot grid
+    p = heatmap(
+        grid.xticks,# .- grid.Δx/2,
+        grid.yticks,#.- grid.Δy/2, 
+        reshape(1:grid.nx*grid.ny,(grid.nx,grid.ny)), 
+        color=heatmap_col,
+        cbar=false  # hide colorbar
+    );
+    
+    # Annotate grid numbering
+    annts = [(pt.x, pt.y, text(i, 7, :white)) for (i, pt) in enumerate(grid.centers)];
+    annotate!(annts...);
+    
+    # Display receivers (floats)
+    rx = [r.x for r in recs]; ry = [r.y for r in recs]
+    scatter!(rx,ry,label="floats");
+    floats_annot = [(pt.x, pt.y, text(i, 10, :bottom)) for (i, pt) in enumerate(recs)];
+    annotate!(floats_annot...);
+    
+    # Display source
+    scatter!([src.x],[src.y],label="source");
+    
+    # Display rays between source and receivers
+    for i in 1:length(recs)
+        plot!([src.x, rx[i]], [src.y, ry[i]], color=3, lab=false);
+    end
+
+    display(p)
+end
+
+end # module

--- a/src/seismic.jl
+++ b/src/seismic.jl
@@ -4,4 +4,6 @@ include("Grids.jl")
 include("Rays.jl")
 include("Inversion.jl")
 
+include("Visualization.jl")
+
 end # module


### PR DESCRIPTION
Add basic visualization of the grid, source, receivers, and ray paths. Mainly for debugging and prototyping.

See example:
![bilde](https://user-images.githubusercontent.com/45243236/111913369-2105dc80-8a6e-11eb-978a-2b38fe74ec3f.png)
