### PR TITLE
feat: relative distance matrix

### DIFF
--- a/src/Grids.jl
+++ b/src/Grids.jl
@@ -1,6 +1,6 @@
 module Grids
 
-export Point, mean_point, distance
+export Point, mean_point, distance, ∠
 export AbstractGrid, Grid, makeGrid
 export bounding_box
 export grid_neighbors
@@ -13,9 +13,31 @@ struct Point{T<:Real}
     y::T
 end
 
-# Basic operations on pairs of points: Compute the distance between them and their midpoint.
+# Basic operations on pairs of points: 
 distance(p::Point, q::Point) = sqrt((p.x-q.x)^2 + (p.y-q.y)^2)
+distance(p::Point{T}) where T<:Number = distance(p, Point(T(0), T(0)))
 mean_point(p::Point, q::Point) = Point((p.x+q.x)/2, (p.y+q.y)/2);
+import Base: +, -, *, /
+(+)(A::Point, B::Point) = Point(A.x + B.x, A.y + B.y)
+(-)(A::Point, B::Point) = Point(A.x - B.x, A.y - B.y)
+(*)(A::Point, x::Number) = Point(A.x * x, A.y * x); (*)(x::Number, A::Point) = A * x
+(/)(A::Point, x::Number) = A * (1/x)
+import LinearAlgebra: dot
+dot(A::Point, B::Point) = A.x * B.x + A.y * B.y; (⋅)(A::Point, B::Point) = dot(A,B)
+
+"""
+    ∠(A, C, B)
+
+Find the angle ∠(ACB) between CA and CB in radians (default).
+"""
+function ∠(A::T, C::T, B::T; in_degrees=false) where T<:Point
+    CA = (A-C) / distance(A,C); CB = (B-C) / distance(B, C)
+    if in_degrees
+        return acosd(CA ⋅ CB)
+    else
+        return acos(CA ⋅ CB)
+    end
+end
 
 
 abstract type AbstractGrid end

--- a/src/Inversion.jl
+++ b/src/Inversion.jl
@@ -47,18 +47,27 @@ function Rxx(grid::AbstractGrid, σ::T, λ::T) where T <: Real
 end
 
 """
-    Rnn(A::AbstractMatrix, σ::Real)
+    Rnn(A::AbstractMatrix, σ::Real, σ_indp::Real)
 
-Compute the prior covariance of the data given correlation level σ.
+Compute the prior covariance of the data given correlation level σ and
+independent noise σ_indp, with A being a slowness measure and noise
+transformation.
 
-Typically, this is the position uncertainty of the floats.
-The correlation level σ is typically expressed as
-`pos. uncertainty` / `wave speed` = `travel time uncertainty` 
+Typically, σ is the position uncertainty of the floats.
+The correlation level Rnn is typically expressed as
+`pos. uncertainty (σ)` * `wave slowness (A)` = `travel time uncertainty (Rnn)`
+The independent noise σ_indp represents noise in waveform correlation or
+independent noise travel-time measurements.
+Typically, the matrix A is the product of the slowness `s` and a mapping
+from receivers to receiver pairs (see also the method `receiverPairs`).
 Units:
-	- σ [time]
+	- σ [length]
+    - σ_indp [time]
+    - A [time / length]
+    - Rnn [time^2]
 """
-function Rnn(A::AbstractMatrix, σ::Real)
-    σ^2 * A * A'
+function Rnn(A::AbstractMatrix, σ::Real, σ_indp::Real)
+    A * (σ^2*I) * A' + σ_indp^2 * I
 end
 
 """
@@ -72,7 +81,7 @@ function Ryy(E::T, rxx::T, rnn::T) where T <: AbstractMatrix
 end
 
 """
-    uncertaintyMatrix(E::T, rxx::T, rnn::T) <: AbstractMatrix
+    uncertaintyMatrix(E::T, rxx::T, rnn::T) where T <: AbstractMatrix
 
 Compute the uncertainty matrix for the linear relation
 	y = Ex + n,


### PR DESCRIPTION
Add construction and inversion using relative distances between floats.

Add independent noise component to `Rnn`, which fixes issue related to perfectly correlated noise in traveltime. 